### PR TITLE
add json, text and table output options

### DIFF
--- a/cmd/vagrant-global-status/main.go
+++ b/cmd/vagrant-global-status/main.go
@@ -1,19 +1,42 @@
 package main
 
 import (
+	"flag"
 	"fmt"
-	"os"
-
 	"github.com/monochromegane/vagrant-global-status"
+	"github.com/monochromegane/vagrant-global-status/printer"
+	"os"
 )
 
 func main() {
-	statuses, err := vagrant.GlobalStatus()
-	if err != nil {
-		fmt.Printf("%v\n", err)
-		os.Exit(1)
+	format := flag.String(
+		"format",
+		"table",
+		"The format to return the details in. Can be table, text, json.",
+	)
+	tmpl := flag.String(
+		"template",
+		"{{.ShortId}}\t{{.Name}}\t{{.Provider}}\t{{.State}}\t{{.VagrantfilePath}}",
+		"The template to output. When using format is table, tab characters specify columns.\nThis option is ignored when format is json.",
+	)
+	flag.Parse()
+
+	machineIndex, err := vagrant.GetMachineIndex()
+	if err == nil {
+		switch *format {
+		case "json":
+			err = printer.PrintJson(os.Stdout, machineIndex)
+		case "table":
+			err = printer.PrintTable(os.Stdout, machineIndex, *tmpl)
+		case "text":
+			err = printer.PrintText(os.Stdout, machineIndex, *tmpl)
+		default:
+			err = fmt.Errorf("Unknown output format %s", *format)
+		}
 	}
-	for _, s := range statuses {
-		fmt.Println(s)
+
+	if err != nil {
+		fmt.Printf("Unexpected error %v", err)
+		os.Exit(1)
 	}
 }

--- a/global_status.go
+++ b/global_status.go
@@ -6,14 +6,13 @@ import (
 	"path/filepath"
 )
 
-// GlobalStatus returns strings like `vagrant global-status` command output.
-func GlobalStatus() ([]string, error) {
+// Returns a MachineIndex pointer that can be queried for a list of Vagrant machines
+func GetMachineIndex() (*MachineIndex, error) {
 	index, err := readMachineIndex()
 	if err != nil {
-		return []string{}, err
+		return nil, err
 	}
-	machineIndex := NewMachineIndex(index)
-	return machineIndex.GlobalStatuses(), nil
+	return NewMachineIndex(index), nil
 }
 
 func readMachineIndex() ([]byte, error) {

--- a/global_status.go
+++ b/global_status.go
@@ -12,7 +12,7 @@ func GetMachineIndex() (*MachineIndex, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewMachineIndex(index), nil
+	return NewMachineIndex(index)
 }
 
 func readMachineIndex() ([]byte, error) {

--- a/machine_index.go
+++ b/machine_index.go
@@ -57,24 +57,3 @@ func (id Id) ToShort() string {
 	reg := regexp.MustCompile("[a-z0-9]{7}")
 	return reg.FindString(string(id))
 }
-
-// ToShort returns the first 7 characters of the id.
-func (m *Machine) GetDataMap(id *Id) map[string]interface{} {
-	data := map[string]interface{}{
-		"LocalDataPath":   m.LocalDataPath,
-		"Name":            m.Name,
-		"Provider":        m.Provider,
-		"State":           m.State,
-		"VagrantfileName": m.VagrantfileName,
-		"VagrantfilePath": m.VagrantfilePath,
-		"UpdatedAt":       m.UpdatedAt,
-		"ExtraData":       m.ExtraData,
-	}
-
-	if id != nil {
-		data["Id"] = string(*id)
-		data["ShortId"] = id.ToShort()
-	}
-
-	return data
-}

--- a/machine_index.go
+++ b/machine_index.go
@@ -43,10 +43,13 @@ type Box struct {
 }
 
 // NewMachineIndex returns MachineIndex from bytes of vagrant machine-index contents.
-func NewMachineIndex(bytes []byte) *MachineIndex {
+func NewMachineIndex(bytes []byte) (*MachineIndex, error) {
 	var machineIndex MachineIndex
-	json.Unmarshal(bytes, &machineIndex)
-	return &machineIndex
+	err := json.Unmarshal(bytes, &machineIndex)
+	if err != nil {
+		return nil, err
+	}
+	return &machineIndex, nil
 }
 
 // ToShort returns the first 7 characters of the id.

--- a/machine_index.go
+++ b/machine_index.go
@@ -2,7 +2,6 @@ package vagrant
 
 import (
 	"encoding/json"
-	"fmt"
 	"regexp"
 )
 
@@ -25,7 +24,7 @@ type Machine struct {
 	Name            string    `json:"name"`
 	Provider        string    `json:"provider"`
 	State           string    `json:"state"`
-	VagrantfileName string    `json"vagrantfile_name"`
+	VagrantfileName string    `json:"vagrantfile_name"`
 	VagrantfilePath string    `json:"vagrantfile_path"`
 	UpdatedAt       string    `json:"updated_at"`
 	ExtraData       ExtraData `json:"extra_data"`
@@ -44,53 +43,35 @@ type Box struct {
 }
 
 // NewMachineIndex returns MachineIndex from bytes of vagrant machine-index contents.
-func NewMachineIndex(bytes []byte) MachineIndex {
+func NewMachineIndex(bytes []byte) *MachineIndex {
 	var machineIndex MachineIndex
 	json.Unmarshal(bytes, &machineIndex)
-	return machineIndex
+	return &machineIndex
 }
 
-// GlobalStatuses returns strings like `vagrant global-status` command output.
-func (mi MachineIndex) GlobalStatuses() []string {
-	var statuses []string
-	for id, m := range mi.Machines {
-		statuses = append(statuses,
-			fmt.Sprintf(mi.formatString(),
-				id.toShort(),
-				m.Name,
-				m.Provider,
-				m.State,
-				m.VagrantfilePath,
-			))
-	}
-	return statuses
-}
-
-func (mi MachineIndex) formatString() string {
-	max := mi.maxColumnLength()
-	return fmt.Sprintf("%%s  %%-%ds %%-%ds %%-%ds %%s",
-		max["name"],
-		max["provider"],
-		max["state"],
-	)
-}
-
-func (mi MachineIndex) maxColumnLength() map[string]int {
-	max := map[string]int{
-		"name":     0,
-		"provider": 0,
-		"state":    0,
-	}
-	for _, m := range mi.Machines {
-		max["name"] = getLongLen(max["name"], len(m.Name))
-		max["provider"] = getLongLen(max["provider"], len(m.Provider))
-		max["state"] = getLongLen(max["state"], len(m.State))
-	}
-	return max
-}
-
-// toShort returns the first 7 characters of the id.
-func (id Id) toShort() string {
+// ToShort returns the first 7 characters of the id.
+func (id Id) ToShort() string {
 	reg := regexp.MustCompile("[a-z0-9]{7}")
 	return reg.FindString(string(id))
+}
+
+// ToShort returns the first 7 characters of the id.
+func (m *Machine) GetDataMap(id *Id) map[string]interface{} {
+	data := map[string]interface{}{
+		"LocalDataPath":   m.LocalDataPath,
+		"Name":            m.Name,
+		"Provider":        m.Provider,
+		"State":           m.State,
+		"VagrantfileName": m.VagrantfileName,
+		"VagrantfilePath": m.VagrantfilePath,
+		"UpdatedAt":       m.UpdatedAt,
+		"ExtraData":       m.ExtraData,
+	}
+
+	if id != nil {
+		data["Id"] = string(*id)
+		data["ShortId"] = id.ToShort()
+	}
+
+	return data
 }

--- a/machine_index_test.go
+++ b/machine_index_test.go
@@ -48,7 +48,10 @@ func TestGlobalStatuses(t *testing.T) {
 	}
 	`
 
-	mi := NewMachineIndex([]byte(index))
+	mi, err := NewMachineIndex([]byte(index))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if len(mi.Machines) != 2 {
 		t.Errorf("It should equal to %d\n", 2)

--- a/machine_index_test.go
+++ b/machine_index_test.go
@@ -1,42 +1,46 @@
 package vagrant
 
-import "testing"
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
 
 func TestGlobalStatuses(t *testing.T) {
 
 	index := `
 	{
-		"version":1,
-		"machines":{
-			"a0123456789012345678901234567890":{
-				"local_data_path":"/Users/user-a/.vagrant",
-				"name":"default",
-				"provider":"virtualbox",
-				"state":"running",
-				"vagrantfile_name":null,
-				"vagrantfile_path":"/Users/user-a/vagrant",
-				"updated_at":null,
-				"extra_data":{
-					"box":{
-						"name":"centos",
-						"provider":"virtualbox",
-						"version":"0"
+		"version": 1,
+		"machines": {
+			"a0123456789012345678901234567890": {
+				"local_data_path": "/Users/user-a/.vagrant",
+				"name": "default",
+				"provider": "virtualbox",
+				"state": "running",
+				"vagrantfile_name": null,
+				"vagrantfile_path": "/Users/user-a/vagrant",
+				"updated_at": null,
+				"extra_data": {
+					"box": {
+						"name": "centos",
+						"provider": "virtualbox",
+						"version": "0"
 					}
 				}
 			},
-			"b0123456789012345678901234567890":{
-				"local_data_path":"/Users/user-b/.vagrant",
-				"name":"development",
-				"provider":"virtualbox",
-				"state":"poweroff",
-				"vagrantfile_name":null,
-				"vagrantfile_path":"/Users/user-b/vagrant",
-				"updated_at":null,
-				"extra_data":{
-					"box":{
-						"name":"centos",
-						"provider":"virtualbox",
-						"version":"0"
+			"b0123456789012345678901234567890": {
+				"local_data_path": "/Users/user-b/.vagrant",
+				"name": "development",
+				"provider": "virtualbox",
+				"state": "poweroff",
+				"vagrantfile_name": null,
+				"vagrantfile_path": "/Users/user-b/vagrant",
+				"updated_at": null,
+				"extra_data": {
+					"box": {
+						"name": "centos",
+						"provider": "virtualbox",
+						"version": "0"
 					}
 				}
 			}
@@ -44,20 +48,62 @@ func TestGlobalStatuses(t *testing.T) {
 	}
 	`
 
-	machines := NewMachineIndex([]byte(index))
-	statuses := machines.GlobalStatuses()
+	mi := NewMachineIndex([]byte(index))
 
-	if len(statuses) != 2 {
+	if len(mi.Machines) != 2 {
 		t.Errorf("It should equal to %d\n", 2)
 	}
 
-	expect := []string{
-		"a012345  default     virtualbox running  /Users/user-a/vagrant",
-		"b012345  development virtualbox poweroff /Users/user-b/vagrant",
+	expect := &MachineIndex{
+		Version: 1,
+		Machines: map[Id]Machine{
+			"a0123456789012345678901234567890": {
+				LocalDataPath: "/Users/user-a/.vagrant",
+				Name: "default",
+				Provider: "virtualbox",
+				State: "running",
+				VagrantfileName: "",
+				VagrantfilePath: "/Users/user-a/vagrant",
+				UpdatedAt: "",
+				ExtraData: ExtraData{
+					Box: Box{
+						Name: "centos",
+						Version: "0",
+						Provider: "virtualbox",
+					},
+				},
+			},
+			"b0123456789012345678901234567890": {
+				LocalDataPath: "/Users/user-b/.vagrant",
+				Name: "development",
+				Provider: "virtualbox",
+				State: "poweroff",
+				VagrantfileName: "",
+				VagrantfilePath: "/Users/user-b/vagrant",
+				UpdatedAt: "",
+				ExtraData: ExtraData{
+					Box: Box{
+						Name: "centos",
+						Version: "0",
+						Provider: "virtualbox",
+					},
+				},
+			},
+		},
 	}
-	for i, status := range statuses {
-		if status != expect[i] {
-			t.Errorf("It should equal to %s\n", expect[i])
+	if !reflect.DeepEqual(mi, expect) {
+		jsonActual, err := json.Marshal(mi)
+		if err != nil {
+			t.Fatal(err)
 		}
+
+		jsonExpected, err := json.Marshal(expect)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t.Log("Failed asserting machine index is correct")
+		t.Logf("Expected %s", jsonExpected)
+		t.Logf("Got      %s", jsonActual)
 	}
 }

--- a/printer/data_map.go
+++ b/printer/data_map.go
@@ -1,0 +1,26 @@
+package printer
+
+import (
+	"github.com/monochromegane/vagrant-global-status"
+)
+
+// ToShort returns the first 7 characters of the id.
+func getDataMap(id *vagrant.Id, m *vagrant.Machine) map[string]interface{} {
+	data := map[string]interface{}{
+		"LocalDataPath":   m.LocalDataPath,
+		"Name":            m.Name,
+		"Provider":        m.Provider,
+		"State":           m.State,
+		"VagrantfileName": m.VagrantfileName,
+		"VagrantfilePath": m.VagrantfilePath,
+		"UpdatedAt":       m.UpdatedAt,
+		"ExtraData":       m.ExtraData,
+	}
+
+	if id != nil {
+		data["Id"] = string(*id)
+		data["ShortId"] = id.ToShort()
+	}
+
+	return data
+}

--- a/printer/json.go
+++ b/printer/json.go
@@ -1,0 +1,17 @@
+package printer
+
+import (
+	"encoding/json"
+	"github.com/monochromegane/vagrant-global-status"
+	"io"
+)
+
+func PrintJson(output io.Writer, mi *vagrant.MachineIndex) error {
+	b, err := json.Marshal(mi)
+	if err != nil {
+		return err
+	}
+
+	_, err = output.Write(b)
+	return err
+}

--- a/printer/table.go
+++ b/printer/table.go
@@ -1,0 +1,28 @@
+package printer
+
+import (
+	"github.com/monochromegane/vagrant-global-status"
+	"io"
+	"text/tabwriter"
+	"text/template"
+)
+
+func PrintTable(output io.Writer, mi *vagrant.MachineIndex, tmpl string) error {
+	t := template.New("table")
+	t, err := t.Parse(tmpl)
+	if err != nil {
+		return err
+	}
+	w := tabwriter.NewWriter(output, 8, 8, 8, ' ', 0)
+
+	var data map[string]interface{}
+	for id, m := range mi.Machines {
+		data = m.GetDataMap(&id)
+		err = t.Execute(w, data)
+		if err != nil {
+			return err
+		}
+	}
+
+	return w.Flush()
+}

--- a/printer/table.go
+++ b/printer/table.go
@@ -13,11 +13,11 @@ func PrintTable(output io.Writer, mi *vagrant.MachineIndex, tmpl string) error {
 	if err != nil {
 		return err
 	}
-	w := tabwriter.NewWriter(output, 8, 8, 8, ' ', 0)
+	w := tabwriter.NewWriter(output, 8, 8, 1, ' ', 0)
 
 	var data map[string]interface{}
 	for id, m := range mi.Machines {
-		data = m.GetDataMap(&id)
+		data = getDataMap(&id, &m)
 		err = t.Execute(w, data)
 		if err != nil {
 			return err

--- a/printer/text.go
+++ b/printer/text.go
@@ -1,0 +1,23 @@
+package printer
+
+import (
+	"github.com/monochromegane/vagrant-global-status"
+	"io"
+	"text/template"
+)
+
+func PrintText(output io.Writer, mi *vagrant.MachineIndex, tmpl string) error {
+	t := template.New("text")
+	t, _ = t.Parse(tmpl)
+
+	var data map[string]interface{}
+	for id, m := range mi.Machines {
+		data = m.GetDataMap(&id)
+		err := t.Execute(output, data)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/printer/text.go
+++ b/printer/text.go
@@ -12,7 +12,7 @@ func PrintText(output io.Writer, mi *vagrant.MachineIndex, tmpl string) error {
 
 	var data map[string]interface{}
 	for id, m := range mi.Machines {
-		data = m.GetDataMap(&id)
+		data = getDataMap(&id, &m)
 		err := t.Execute(output, data)
 		if err != nil {
 			return err


### PR DESCRIPTION
This PR adds additional output formats including `json`, `text`, and `table` and abstracts the output away from the main MachineIndex struct.

The default output format has been set to table for backwards compatibility.

It also allows individuals to select what to output when they use an output format of `text` or `table`. The default for this is also backwards compatibility.